### PR TITLE
Fix map rendering to be correct

### DIFF
--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -1,17 +1,30 @@
-import { useState, useRef } from "react"
+import { useState, useEffect } from "react"
 import { Map, Marker } from "pigeon-maps"
+
+function getWindowSize(): [number, number] {
+  const {innerWidth, innerHeight} = window;
+  return [innerWidth, innerHeight];
+}
 
 export default function MyMap() {
   const [hue, setHue] = useState(0)
   const color = `hsl(${hue % 360}deg 39% 70%)`
 
-  const height = useRef(window.innerHeight);
-  const width = useRef(window.innerWidth);
-
   const linkoping: [number, number] = [58.4, 15.625278];
 
+  const [windowSize, setWindowSize] = useState(getWindowSize());
+
+  const handleWindowResize = () => {
+      setWindowSize(getWindowSize());
+  } 
+
+  useEffect(() => {
+    window.addEventListener('resize', handleWindowResize);
+    return () => { window.removeEventListener('resize', handleWindowResize) };
+  }, []);
+
   return (
-    <Map height={height.current} width={width.current}
+    <Map width={windowSize[0]} height={windowSize[1]-65}
 
     defaultCenter={linkoping} defaultZoom={11}>
       <Marker 
@@ -25,9 +38,7 @@ export default function MyMap() {
         anchor={[58.45, 15.6]}
         color={color} 
         onClick={() => setHue(hue + 20)} 
-      >
-
-      </Marker>
+      />
     </Map>
   )
 }

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -8,19 +8,21 @@ export default function MyMap() {
   const height = useRef(window.innerHeight);
   const width = useRef(window.innerWidth);
 
+  const linkoping: [number, number] = [58.4, 15.625278];
+
   return (
     <Map height={height.current} width={width.current}
 
-    defaultCenter={[50.879, 4.6997]} defaultZoom={11}>
+    defaultCenter={linkoping} defaultZoom={11}>
       <Marker 
         width={50}
-        anchor={[50.879, 4.6997]} 
+        anchor={[58.5, 15.65]}
         color={color} 
         onClick={() => setHue(hue + 20)} 
       />
       <Marker 
         width={50}
-        anchor={[50.879, 4.6997]} 
+        anchor={[58.45, 15.6]}
         color={color} 
         onClick={() => setHue(hue + 20)} 
       >

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -68,7 +68,7 @@ function ResponsiveAppBar() {
     };
 
     return (
-        <AppBar position="fixed" sx={{ backgroundColor: "#1F3559" }}>
+        <AppBar position="sticky" sx={{ backgroundColor: "#1F3559" }}>
             <Container maxWidth={false}>
                 <Toolbar disableGutters>
                 <Box>


### PR DESCRIPTION
The headerbar was rendered using "fixed" and not "static" meaning that it rendered over other components. I still need to figure out how to get the size of the area the map is within but right now it works okay ish to do window size minus 65. It also follows the window resizing now instead of being fixed to the initial window size.

Added bonus: The map is now centred in Linköping with the markers in Roxen.